### PR TITLE
RSS AWS #10: Add bff api proxy

### DIFF
--- a/bff/.gitignore
+++ b/bff/.gitignore
@@ -1,0 +1,5 @@
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/bff/Dockerfile
+++ b/bff/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+
+FROM public.ecr.aws/docker/library/golang:1.20-alpine as  build
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY ./ /app/
+
+RUN go build -o /bff main.go
+
+FROM public.ecr.aws/docker/library/alpine:latest as prod
+
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache ca-certificates \
+    && update-ca-certificates
+
+WORKDIR /
+
+COPY --from=build /bff /bff
+
+EXPOSE 80
+
+CMD ["/bff"]

--- a/bff/go.mod
+++ b/bff/go.mod
@@ -1,0 +1,5 @@
+module github.com/peterm-itr/bff
+
+go 1.20
+
+require github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/bff/go.sum
+++ b/bff/go.sum
@@ -1,0 +1,2 @@
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=

--- a/bff/main.go
+++ b/bff/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha1"
+	"errors"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+)
+
+var proxyCache cache.Cache
+
+type CachingTransport struct{}
+
+func shouldCacheURL(method string, url *url.URL) bool {
+	if strings.ToLower(method) != "get" {
+		return false
+	}
+
+	if !strings.Contains(url.Path, "/products") {
+		return false
+	}
+
+	return true
+}
+
+func (CachingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	hash := sha1.Sum([]byte(r.URL.String()))
+	cacheKey := string(hash[:])
+
+	if x, found := proxyCache.Get(cacheKey); found {
+		respDump := x.([]byte)
+
+		return http.ReadResponse(bufio.NewReader(bytes.NewReader(respDump)), r)
+	}
+
+	resp, err := http.DefaultTransport.RoundTrip(r)
+
+	if err == nil && shouldCacheURL(r.Method, r.URL) {
+		dump, _ := httputil.DumpResponse(resp, true)
+		proxyCache.Add(cacheKey, dump, cache.DefaultExpiration)
+	}
+
+	return resp, err
+}
+
+var proxyUrls map[string]string
+
+func getProxyURL(req *http.Request) (*string, error) {
+	// path := req.URL.Path
+	parts := strings.Split(req.URL.Path, "/")
+
+	serviceName := parts[1]
+
+	if len(serviceName) == 0 {
+		return nil, errors.New("incorrect path")
+	}
+
+	proxy, pOk := proxyUrls[serviceName]
+
+	if !pOk {
+		return nil, errors.New("unknown service")
+	}
+
+	return &proxy, nil
+}
+
+func serveReverseProxy(target string, res http.ResponseWriter, req *http.Request) {
+	url, _ := url.Parse(target)
+
+	proxy := httputil.NewSingleHostReverseProxy(url)
+	proxy.Transport = CachingTransport{}
+	req.Host = req.URL.Host
+
+	// Note that ServeHttp is non-blocking and uses a go routine under the hood
+	proxy.ServeHTTP(res, req)
+}
+
+// Given a request send it to the appropriate url
+func handleRequestAndForward(res http.ResponseWriter, req *http.Request) {
+	proxyUrl, err := getProxyURL(req)
+
+	if err != nil {
+		res.WriteHeader(502)
+
+		return
+	}
+
+	serveReverseProxy(*proxyUrl, res, req)
+}
+
+func main() {
+	proxyUrls = map[string]string{
+		"profile":  os.Getenv("CART_BASE_URL"),
+		"products": os.Getenv("PRODUCTS_BASE_URL"),
+	}
+	proxyCache = *cache.New(120*time.Second, 5*time.Second)
+
+	http.HandleFunc("/", handleRequestAndForward)
+	log.Fatalln(http.ListenAndServe(`:80`, nil))
+}


### PR DESCRIPTION
* Task: https://github.com/rolling-scopes-school/aws/blob/main/aws-developer/10_backend_for_frontend/task.md
* Self-check: 100/100
  * Main scope implemented
  * Caching for Products API Calls implemented (you can click 'Add product' button at [Manage Products](https://d1xaanpmmg0wvm.cloudfront.net/admin/products) and it won't appear in the list immediately after form submission)

---
⚠️: FE uses basic auth for the cart api. You can use the following token (`authorization_token` in local storage) for testing or create your own `cGV0ZXJtLWl0cjpURVNUX1BBU1NXT1JECg==`
Otherwise you'll get 401 Unauthorized for cart api requests

---

### Links

* BFF API direct link: http://peterm-itr-bff-api-prod.us-east-1.elasticbeanstalk.com
* BFF API via API GW for TLS termination: https://4q80qn94if.execute-api.us-east-1.amazonaws.com
* Cart API GW Endpoint https://hc1da1z0ci.execute-api.us-east-1.amazonaws.com/prod/api/profile/cart
* Products API GW Endpoint https://49x3bleq23.execute-api.us-east-1.amazonaws.com/prod/v1/products

---

### Proxy mapping:

| Proxy URL | Destination | Is Cached |
|---|---|---|
|  https://4q80qn94if.execute-api.us-east-1.amazonaws.com/profile/cart | https://hc1da1z0ci.execute-api.us-east-1.amazonaws.com/prod/api/profile/cart | - |
|  https://4q80qn94if.execute-api.us-east-1.amazonaws.com/products |  https://49x3bleq23.execute-api.us-east-1.amazonaws.com/prod/v1/products | + |
|  https://4q80qn94if.execute-api.us-east-1.amazonaws.com/products/available |  https://49x3bleq23.execute-api.us-east-1.amazonaws.com/prod/v1/products/available | + |

---

* FE PR: https://github.com/peterm-itr/nodejs-aws-shop-react/pull/6
* FE URL: https://d1xaanpmmg0wvm.cloudfront.net/
